### PR TITLE
Fixed SyntaxWarning on python 3.10+

### DIFF
--- a/run_storm.py
+++ b/run_storm.py
@@ -12,16 +12,16 @@ from colorama import Fore, Style
 colorama.init()
 
 # Print a nice banner
-print(f"""
+print(rf"""
 {Fore.CYAN}╔═══════════════════════════════════════════════════════════╗
-║ {Fore.YELLOW}  _____ _______ ____  _____  __  __ {Fore.CYAN}                    ║
-║ {Fore.YELLOW} / ____|__   __/ __ \|  __ \|  \/  |{Fore.CYAN}                    ║
-║ {Fore.YELLOW}| (___    | | | |  | | |__) | \  / |{Fore.CYAN}                    ║
-║ {Fore.YELLOW} \___ \   | | | |  | |  _  /| |\/| |{Fore.CYAN}                    ║
-║ {Fore.YELLOW} ____) |  | | | |__| | | \ \| |  | |{Fore.CYAN}                    ║
-║ {Fore.YELLOW}|_____/   |_|  \____/|_|  \_\_|  |_|{Fore.CYAN}                    ║
-║                                                   ║
-║ {Fore.GREEN}RPC Flood Testing Tool{Fore.CYAN}                              ║
+║ {Fore.YELLOW}  _____ _______ ____  _____  __  __ {Fore.CYAN}                      ║
+║ {Fore.YELLOW} / ____|__   __/ __ \|  __ \|  \/  |{Fore.CYAN}                      ║
+║ {Fore.YELLOW}| (___    | | | |  | | |__) | \  / |{Fore.CYAN}                      ║
+║ {Fore.YELLOW} \___ \   | | | |  | |  _  /| |\/| |{Fore.CYAN}                      ║
+║ {Fore.YELLOW} ____) |  | | | |__| | | \ \| |  | |{Fore.CYAN}                      ║
+║ {Fore.YELLOW}|_____/   |_|  \____/|_|  \_\_|  |_|{Fore.CYAN}                      ║
+║                                                           ║
+║ {Fore.GREEN}RPC Flood Testing Tool{Fore.CYAN}                                    ║
 ╚═══════════════════════════════════════════════════════════╝{Style.RESET_ALL}
 """)
 


### PR DESCRIPTION
I've got a couple  messages like
```
run_storm.py:26: SyntaxWarning: invalid escape sequence '\|'
  """)
```
while running this app on python 3.10+ 
This PR will fix these warnings and a glitched splashscreen as well. It will not break application on python 3.9 (which is used in Dockerfile).